### PR TITLE
Using tempfile for zip_inplace

### DIFF
--- a/tests/test__internal.py
+++ b/tests/test__internal.py
@@ -90,14 +90,6 @@ def test_zip_inplace(tmpdir):
         assert zf.read("boo.bin") == b
 
 
-def test_zip_inplace_replace(tmpdir):
-    zip_path = zip_inplace(str(tmpdir))
-    os.truncate(zip_path, 0)
-    assert os.path.getsize(zip_path) == 0
-    zip_inplace(str(tmpdir), replace=True)
-    assert os.path.getsize(zip_path) > 0
-
-
 def test_static_default_dict():
     d = StaticDefaultDict({"foo": 42}, default=100500)
     assert d["foo"] == 42

--- a/tf_yarn/_internal.py
+++ b/tf_yarn/_internal.py
@@ -121,21 +121,26 @@ def xset_environ(**kwargs):
     os.environ.update(kwargs)
 
 
-def zip_inplace(path, replace=False):
+def zip_inplace(path):
+    """
+    Create a zip archive out of an existing directory path
+    :param path: the path to a an existing directory
+    :return: the path of the created archive
+    """
     assert os.path.exists(path) and os.path.isdir(path)
 
-    zip_path = path + ".zip"
-    if not os.path.exists(zip_path) or replace:
-        created = shutil.make_archive(
-            os.path.basename(path),
-            "zip",
-            root_dir=path)
+    created = shutil.make_archive(
+        os.path.basename(path),
+        "zip",
+        root_dir=path)
 
-        try:
-            shutil.move(created, zip_path)
-        except OSError as e:
-            os.remove(created)  # Cleanup on failure.
-            raise e from None
+    try:
+        zip_path = shutil.move(
+            created,
+            tempfile.mkstemp(suffix=".zip")[1])
+    except OSError as e:
+        os.remove(created)  # Cleanup on failure.
+        raise e from None
     return zip_path
 
 


### PR DESCRIPTION
* zip_path in zip_inplace function was
  directly built on the original path
  by appending ".zip", resulting in race
  conditions
* We now use tempfile.mkstemp to generate
  a new filepath
* We clean the local assets (zip files)
  as soon as the application has been accepted
  by yarn