### PR TITLE
added  a feature to fix the issue#13

### DIFF
--- a/examples/linear_classifier_experiment.py
+++ b/examples/linear_classifier_experiment.py
@@ -65,5 +65,6 @@ if __name__ == "__main__":
             "chief": TaskSpec(memory=2 * 2 ** 10, vcores=4),
             "evaluator": TaskSpec(memory=2 ** 10, vcores=1)
         },
-        files={os.path.basename(winequality.__file__): winequality.__file__}
+        files={os.path.basename(winequality.__file__): winequality.__file__},
+        num_threads= 2
         )

--- a/examples/linear_classifier_experiment.py
+++ b/examples/linear_classifier_experiment.py
@@ -58,13 +58,12 @@ if __name__ == "__main__":
 
     logging.basicConfig(level="INFO")
     
-
+    #also one can use run_on_yarn(...,num_cores=num_cores) where num_cores is the user specified value, otherwise the default is 1
     run_on_yarn(
         partial(experiment_fn, dataset_path),
         task_specs={
             "chief": TaskSpec(memory=2 * 2 ** 10, vcores=4),
             "evaluator": TaskSpec(memory=2 ** 10, vcores=1)
-            #also one can add num_cores=num_cores here where num_cores value is user specified, otherwise the default is 1
         },
         files={os.path.basename(winequality.__file__): winequality.__file__}
         )

--- a/examples/linear_classifier_experiment.py
+++ b/examples/linear_classifier_experiment.py
@@ -58,13 +58,13 @@ if __name__ == "__main__":
 
     logging.basicConfig(level="INFO")
     
-   
+
     run_on_yarn(
         partial(experiment_fn, dataset_path),
         task_specs={
             "chief": TaskSpec(memory=2 * 2 ** 10, vcores=4),
             "evaluator": TaskSpec(memory=2 ** 10, vcores=1)
+            #also one can add num_cores=num_cores here where num_cores value is user specified, otherwise the default is 1
         },
-        files={os.path.basename(winequality.__file__): winequality.__file__},
-        num_threads= 2
+        files={os.path.basename(winequality.__file__): winequality.__file__}
         )

--- a/tf_yarn/__init__.py
+++ b/tf_yarn/__init__.py
@@ -101,10 +101,12 @@ def run_on_yarn(
     pip_packages: typing.List[str] = None,
     files: typing.Dict[str, str] = None,
     env: typing.Dict[str, str] = {},
+    num_threads: int ,
     queue: str = "default",
     file_systems: typing.List[str] = None,
     log_conf_file: str = None
 ) -> None:
+
     """Run an experiment on YARN.
 
     The implementation allocates a service with the requested number
@@ -226,7 +228,7 @@ def run_on_yarn(
         for task_type, task_spec in list(task_specs.items()):
             pyenv = pyenvs[task_spec.label]
             services[task_type] = skein.Service(
-                [gen_task_cmd(pyenv, num_ps, num_workers, log_conf_file)],
+                [gen_task_cmd(pyenv, num_ps, num_workers, num_threads, log_conf_file)], 
                 skein.Resources(task_spec.memory, task_spec.vcores),
                 max_restarts=0,
                 instances=task_spec.instances,

--- a/tf_yarn/__init__.py
+++ b/tf_yarn/__init__.py
@@ -59,7 +59,6 @@ class Experiment(typing.NamedTuple):
     eval_spec: tf.estimator.EvalSpec
 
     # TODO: experiment name?
-
     @property
     def config(self) -> tf.estimator.RunConfig:
         return self.estimator.config
@@ -101,7 +100,7 @@ def run_on_yarn(
     pip_packages: typing.List[str] = None,
     files: typing.Dict[str, str] = None,
     env: typing.Dict[str, str] = {},
-    num_threads: int = 1,
+    num_cores: int = 1,
     queue: str = "default",
     file_systems: typing.List[str] = None,
     log_conf_file: str = None
@@ -228,7 +227,7 @@ def run_on_yarn(
         for task_type, task_spec in list(task_specs.items()):
             pyenv = pyenvs[task_spec.label]
             services[task_type] = skein.Service(
-                [gen_task_cmd(pyenv, num_ps, num_workers, num_threads, log_conf_file)], 
+                [gen_task_cmd(pyenv, num_ps, num_workers, num_cores, log_conf_file)], 
                 skein.Resources(task_spec.memory, task_spec.vcores),
                 max_restarts=0,
                 instances=task_spec.instances,

--- a/tf_yarn/__init__.py
+++ b/tf_yarn/__init__.py
@@ -101,7 +101,7 @@ def run_on_yarn(
     pip_packages: typing.List[str] = None,
     files: typing.Dict[str, str] = None,
     env: typing.Dict[str, str] = {},
-    num_threads: int = 0,
+    num_threads: int = 1,
     queue: str = "default",
     file_systems: typing.List[str] = None,
     log_conf_file: str = None

--- a/tf_yarn/__init__.py
+++ b/tf_yarn/__init__.py
@@ -101,7 +101,7 @@ def run_on_yarn(
     pip_packages: typing.List[str] = None,
     files: typing.Dict[str, str] = None,
     env: typing.Dict[str, str] = {},
-    num_threads: int ,
+    num_threads: int = 0,
     queue: str = "default",
     file_systems: typing.List[str] = None,
     log_conf_file: str = None

--- a/tf_yarn/_dispatch_task.py
+++ b/tf_yarn/_dispatch_task.py
@@ -39,7 +39,7 @@ from ._internal import (
 def main(
     experiment_fn: ExperimentFn,
     all_tasks: typing.List[str],
-    num_threads : int = 0
+    num_threads : int 
 ) -> None:
 
 
@@ -118,9 +118,10 @@ def main(
         config = experiment.config
         assert config.task_type == task_type and config.task_id == task_id
     
-    server_config = tf.ConfigProto()
-    server_config.intra_op_parallelism_threads=num_threads
-    server_config.inter_op_parallelism_threads=num_threads
+    server_config = tf.ConfigProto(log_device_placement=True,
+                                   intra_op_parallelism_threads=num_threads,
+                                   inter_op_parallelism_threads=num_threads)
+
     if fake_google_env:
 
         tf.train.Server(

--- a/tf_yarn/_dispatch_task.py
+++ b/tf_yarn/_dispatch_task.py
@@ -39,7 +39,7 @@ from ._internal import (
 def main(
     experiment_fn: ExperimentFn,
     all_tasks: typing.List[str],
-    num_threads : int 
+    num_cores : int 
 ) -> None:
 
 
@@ -116,11 +116,10 @@ def main(
             raise
 
         config = experiment.config
+        #adding the number of the cores here to the config
+        config.session_config.intra_op_parallelism_threads=num_cores
+        config.session_config.inter_op_parallelism_threads=num_cores
         assert config.task_type == task_type and config.task_id == task_id
-    
-    server_config = tf.ConfigProto(log_device_placement=True,
-                                   intra_op_parallelism_threads=num_threads,
-                                   inter_op_parallelism_threads=num_threads)
 
     if fake_google_env:
 
@@ -128,7 +127,7 @@ def main(
             config.cluster_spec,
             job_name=config.task_type,
             task_index=config.task_id,
-            config=server_config,
+            config=config.session_config,
             start=True)
 
     tf.logging.info(f"Starting {task_type}:{task_id}")
@@ -224,7 +223,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-ps", type=int)
     parser.add_argument("--experiment-fn", type=load_fn)
     parser.add_argument("--log-conf-file", type=str)
-    parser.add_argument("--num-threads",type=int)
+    parser.add_argument("--num-cores",type=int)
     args = parser.parse_args()
     _setup_logging(args.log_conf_file)
-    main(args.experiment_fn, list(iter_tasks(args.num_workers, args.num_ps)),args.num_threads) 
+    main(args.experiment_fn, list(iter_tasks(args.num_workers, args.num_ps)),args.num_cores) 

--- a/tf_yarn/_env.py
+++ b/tf_yarn/_env.py
@@ -30,11 +30,12 @@ def gen_pyenv_from_existing_archive(path_to_archive: str
 def gen_task_cmd(pyenv: PythonEnvDescription,
                  num_ps: int,
                  num_workers: int,
+                 num_threads: int, 
                  log_conf_file: typing.Optional[str]) -> str:
 
     conf_args = f"--log-conf-file={log_conf_file}" if log_conf_file is not None else ""
 
     return (f"{pyenv.dispatch_task_cmd} "
-            f"--num-ps={num_ps} --num-workers={num_workers} "
+            f"--num-ps={num_ps} --num-workers={num_workers} --num-threads={num_threads} " 
             f"--experiment-fn=experiment_fn.dill " + conf_args
             )

--- a/tf_yarn/_env.py
+++ b/tf_yarn/_env.py
@@ -30,12 +30,12 @@ def gen_pyenv_from_existing_archive(path_to_archive: str
 def gen_task_cmd(pyenv: PythonEnvDescription,
                  num_ps: int,
                  num_workers: int,
-                 num_threads: int, 
+                 num_cores: int, 
                  log_conf_file: typing.Optional[str]) -> str:
 
     conf_args = f"--log-conf-file={log_conf_file}" if log_conf_file is not None else ""
 
     return (f"{pyenv.dispatch_task_cmd} "
-            f"--num-ps={num_ps} --num-workers={num_workers} --num-threads={num_threads} " 
+            f"--num-ps={num_ps} --num-workers={num_workers} --num-cores={num_cores} " 
             f"--experiment-fn=experiment_fn.dill " + conf_args
             )


### PR DESCRIPTION
I have added  a couple of features into the config used in  tf.train.Server(): 1) config.intra_op_parallelism_threads=thread_num, and 2) config.inter_op_parallelism_threads=thread_num, to limit the number of real cores in each container so addressing the issue#13. I also added a small fix into the example to avoid a crash by introducing and id number of each job.  The run would be: run_on_yarn(..., num_threads=X), where X can be set by the user--so adding one additional argument to run_on_yarn(...)