### PR TITLE
Write as bytes instead of string to mlflow.

### DIFF
--- a/tf_yarn/mlflow.py
+++ b/tf_yarn/mlflow.py
@@ -140,6 +140,6 @@ def save_text_to_mlflow(content, filename):
     logger.info(f"save file {filename} to mlflow")
     with tempfile.TemporaryDirectory() as tempdir:
         path = os.path.join(tempdir, filename)
-        with open(path, 'w') as f:
-            f.write(content)
+        with open(path, 'wb') as f:
+            f.write(content.encode())
         mlflow.log_artifact(path)


### PR DESCRIPTION
Robust if a part of the string has a wrong encoding.

I had the following issue: in the log file I had a warning coming from nltk stating
>DeprecationWarning: invalid escape sequence \]
>FUNKY_PUNCT_1 = re.compile(u'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])')

And while 
```python
s = """DeprecationWarning: invalid escape sequence \]
FUNKY_PUNCT_1 = re.compile(u'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])')"""

with open('example.txt', 'wb') as output_file:
    output_file.write(s.encode())
```
works,

```python
with open('example.txt', 'w') as output_file:
    output_file.write(s)
```
fails.