### PR TITLE
Bump skein version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cluster-pack
-skein==0.8.0
+skein>=0.8,<0.9


### PR DESCRIPTION
New skein version (0.8.1) has been released on March 2nd (https://github.com/jcrist/skein/blob/master/docs/source/changelog.rst#version-081-mar-2-2021).

Having a fixed version in tf-yarn disallow its dependencies to update skein (https://github.com/criteo/deepr/pull/179)