### PR TITLE
Fix mypy issue for target_data_fn

### DIFF
--- a/tf_yarn/keras_experiment.py
+++ b/tf_yarn/keras_experiment.py
@@ -1,11 +1,11 @@
 import tensorflow as tf
-from typing import NamedTuple, Callable
+from typing import NamedTuple, Callable, Optional
 
 
 class KerasExperiment(NamedTuple):
     model: tf.keras.models.Model
     model_dir: str
     train_params: dict
-    input_data_fn: Callable
-    target_data_fn: Callable
+    input_data_fn: Optional[Callable]
+    target_data_fn: Optional[Callable]
     validation_data_fn: Callable


### PR DESCRIPTION
Command
```
python -m mypy . --ignore-missing-imports
```

Was failing with
```
examples/native_keras_with_gloo_example.py:89: error: Argument "target_data_fn" to "KerasExperiment" has incompatible type "None"; expected "Callable[..., Any]"
```