### PR TITLE
Pytorch training: drop last batch by default in the data loader

### DIFF
--- a/tf_yarn/pytorch/experiment.py
+++ b/tf_yarn/pytorch/experiment.py
@@ -7,7 +7,12 @@ class DataLoaderArgs(NamedTuple):
     batch_size: Optional[int] = 1
     num_workers: int = 0
     pin_memory: bool = False
-    drop_last: bool = False
+    # /!\ Not dropping the last batch could result in a smaller
+    # batch size which could block your distributed training when aggregating
+    # tensors with allreduce/allgather. It will cause a memory corruption on
+    # the worker processing the smaller batch size and your training will fail
+    # or simply freeze
+    drop_last: bool = True
     timeout: float = 0
     prefetch_factor: int = 2
     shuffle: bool = False

--- a/tf_yarn/pytorch/tasks/worker.py
+++ b/tf_yarn/pytorch/tasks/worker.py
@@ -42,6 +42,12 @@ def _create_dataloader(
     sampler: Optional[DistributedSampler] = \
         DistributedSampler(dataset, shuffle=dataloader_args.shuffle) \
         if not isinstance(dataset, torch.utils.data.IterableDataset) else None
+    if not dataloader_args.drop_last:
+        _logger.error("/!\ Not dropping the last batch could result in a smaller "
+                      "batch size which could block your distributed training when aggregating "
+                      "tensors with allreduce/allgather. It will cause a memory corruption on "
+                      "the worker processing the smaller batch size and your training will fail "
+                      "or simply freeze. We strongly encourage setting DataLoaderArgs.drop_last to True")
     return torch.utils.data.DataLoader(
         dataset, sampler=sampler, batch_size=dataloader_args.batch_size,
         num_workers=dataloader_args.num_workers, pin_memory=dataloader_args.pin_memory,

--- a/tf_yarn/pytorch/tasks/worker.py
+++ b/tf_yarn/pytorch/tasks/worker.py
@@ -43,11 +43,12 @@ def _create_dataloader(
         DistributedSampler(dataset, shuffle=dataloader_args.shuffle) \
         if not isinstance(dataset, torch.utils.data.IterableDataset) else None
     if not dataloader_args.drop_last:
-        _logger.error("/!\ Not dropping the last batch could result in a smaller "
+        _logger.error("/!\\ Not dropping the last batch could result in a smaller "
                       "batch size which could block your distributed training when aggregating "
                       "tensors with allreduce/allgather. It will cause a memory corruption on "
                       "the worker processing the smaller batch size and your training will fail "
-                      "or simply freeze. We strongly encourage setting DataLoaderArgs.drop_last to True")
+                      "or simply freeze. We strongly encourage setting DataLoaderArgs.drop_last "
+                      "to True")
     return torch.utils.data.DataLoader(
         dataset, sampler=sampler, batch_size=dataloader_args.batch_size,
         num_workers=dataloader_args.num_workers, pin_memory=dataloader_args.pin_memory,


### PR DESCRIPTION
Not dropping the last batch could result in a smaller batch size which could block your distributed training when aggregating tensors with allreduce/allgather. It will cause a memory corruption on the worker processing the smaller batch size and your training will fail or simply freeze