### PR TITLE
[tf_yarn.pytorch] Add support to webdataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A Pytorch experiment is described by an instance of `tf_yarn.pytorch.PytorchExpe
 
 - model: model to train
 - main_fn: Main function run to train the model. This function is executed by all workers involved in the training. It must accept these inputs: model to train, train dataloader, device (cpu:0, cpu:1, cuda:0, cuda:1 ...) allocated to the worker for the training and rank (worker id).
-- Training dataset: training dataset (instance of `torch.utils.data.Dataset`).
+- Training dataset: training dataset (instance of `torch.utils.data.Dataset`, `webdataset.WebDataset` or `webdataset.DataPipeline`).
 - dataloader_args: parameters (batch size, number of workers, collate function ...) passed to the dataloader used to load and iterate over the training dataset. Instance of `tf_yarn.pytorch.DataLoaderArgs`.
 - n_workers_per_executor: number of workers per yarn executor.
 - tensorboard_hdfs_dir: HDFS directory where tensorboard results will be written at the end of the training

--- a/tf_yarn/pytorch/experiment.py
+++ b/tf_yarn/pytorch/experiment.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Callable, Optional
+from typing import Callable, NamedTuple, Optional
 
 import torch
 
@@ -16,6 +16,7 @@ class DataLoaderArgs(NamedTuple):
     timeout: float = 0
     prefetch_factor: int = 2
     shuffle: bool = False
+    persistent_workers: bool = False
 
 
 class DistributedDataParallelArgs(NamedTuple):
@@ -35,7 +36,7 @@ class PytorchExperiment(NamedTuple):
     # outputs: None
     main_fn: Callable[
         [torch.nn.Module, torch.utils.data.dataloader.DataLoader, str, int],
-        None
+        None,
     ]
 
     # Training set


### PR DESCRIPTION
- Instantiate a `webdataset.WebLoader` when a `wds.WebDataset` or a `wds.DataPipeline` is passed as the dataset
- Add `persistent_workers` argument to the `tf_yarn.pytorch.DataLoaderArgs`
- Update the README

fix #99 